### PR TITLE
fix QueryGrammar null error

### DIFF
--- a/src/Http/Livewire/LivewireDatatable.php
+++ b/src/Http/Livewire/LivewireDatatable.php
@@ -414,7 +414,7 @@ class LivewireDatatable extends Component
                     if ($column->select instanceof Expression) {
                         $sep_string = config('database.default') === 'pgsql' ? '"' : '`';
 
-                        return new Expression($column->select->getValue(DB::getSchemaGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
+                        return new Expression($column->select->getValue(DB::connection()->getQueryGrammar()) . ' AS ' . $sep_string . $column->name . $sep_string);
                     }
 
                     if (is_array($column->select)) {


### PR DESCRIPTION
`DB::getSchemaGrammar` returns null fix