### PR TITLE
ComplexQuery, hideable and pagination issues resolved

### DIFF
--- a/resources/views/livewire/datatables/complex-query.blade.php
+++ b/resources/views/livewire/datatables/complex-query.blade.php
@@ -2,8 +2,8 @@
         rules: @if($persistKey) $persist('').as('{{ $persistKey }}') @else '' @endif,
         init() {
             Livewire.on('complexQuery', rules => this.rules = rules)
-            if (this.rules && this.rules !== '') {
-                $wire.set('rules', this.rules)
+            if (this.rules && this.rules !== '' && this.rules.rules !== null) {
+                $wire.set('rules', this.rules.rules)
                 $wire.runQuery()
             }
         }

--- a/src/Column.php
+++ b/src/Column.php
@@ -24,7 +24,7 @@ class Column implements \ArrayAccess
     public bool $sortable = false;
     public string|array|null $filterOn = null;
     public bool|array $filterable = false;
-    public bool $hideable;
+    public string|bool|null $hideable = null;
     public ?string $sort = null;
     public bool|string $defaultSort = false;
     public string|array|Closure|null $callback = null;

--- a/src/Livewire/ComplexQuery.php
+++ b/src/Livewire/ComplexQuery.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class ComplexQuery extends Component
@@ -88,6 +89,7 @@ class ComplexQuery extends Component
     public function resetQuery(): void
     {
         $this->reset('rules');
+        $this->dispatch('refreshLivewireDatatable');
         $this->runQuery();
     }
 

--- a/src/Livewire/LivewireDatatable.php
+++ b/src/Livewire/LivewireDatatable.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithPagination;
 use RuntimeException;
@@ -1273,8 +1274,6 @@ class LivewireDatatable extends Component
         $this->query->where(function ($query) {
             $this->processNested($this->complexQuery, $query);
         });
-
-        $this->setPage(1);
 
         return $this;
     }


### PR DESCRIPTION
- Column::hideable string|bool|null has been made possible. Fixed the issue of adding mandatory ->hideable() method in all fields.
- ComplexQuery dispatch event rules parameter differed with persistKey data. Complex Query Undefined array key 0. problem solved
- In the LivewireDatatable addComplexQuery method, $this->setPage(1), which forces pagination to the 1st page, has been removed and pagination has been activated. At the same time, ComplexQuery can add $this->dispatch('refreshLivewireDatatable'); to the resetQuery method to redirect to the 1st page when the reset button is pressed. added and redirected to page 1.